### PR TITLE
resolved deprecation unarchiveTopLevelObjectWithData

### DIFF
--- a/complete-application/ChangeBank/UserAuth.swift
+++ b/complete-application/ChangeBank/UserAuth.swift
@@ -95,11 +95,12 @@ class UserAuth: ObservableObject {
             return
         }
         do {
-            let authState = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data) as? OIDAuthState
+            let authState = try NSKeyedUnarchiver.unarchivedObject(ofClasses: [OIDAuthState.self], from: data) as? OIDAuthState
             self.setAuthState(state: authState)
             // Fetch user info if user authenticated
             fetchUserInfo()
        } catch {
+           self.setAuthState(state: nil)
            print(error)
        }
    }


### PR DESCRIPTION
I did set nil in the catch, cause unarchiveTopLevelObjectWithData would have set the authState nil when erroring.
And I don't know if you like to suppress the error message by catching NSError separately.